### PR TITLE
modifies selector.grab_stdout() to also return the PID of the spawned…

### DIFF
--- a/tasks/selector-nixio.lua
+++ b/tasks/selector-nixio.lua
@@ -312,7 +312,7 @@ M.init = function(conf)
       if pid > 0 then 
         --parent
         fdo:close()
-        return fdi
+        return fdi, pid
       else
         --child
         nixio.dup(fdo, nixio.stdout)
@@ -330,7 +330,7 @@ M.init = function(conf)
     sktd.events = {data=sktd.fd}
     if sktd.pattern=='*l' and handler == 'stream' then sktd.pattern=nil end
     register_client(sktd)
-    return sktd
+    return sktd, pid
   end
   M.close = function(sktd)
     --sktd.polle.do_not_read = true

--- a/tasks/selector.lua
+++ b/tasks/selector.lua
@@ -102,6 +102,7 @@ M.init = function(conf)
 	-- will be closed with the error message as provided by the socket.  
 	-- If the handler parameter is nil, the socket object will emit signals. 
 	-- @return a @{sktd} object
+	-- @return the Process ID (PID) of the spawned process
 	M.grab_stdout = native.grab_stdout 
 	
 	--- Closes a socket/file.


### PR DESCRIPTION
… process, which can be used to get the exit status of the process by using nixio.wait(). This might not be the best way of achieving this but is at least workable.